### PR TITLE
Fix GNU grep compatibility.

### DIFF
--- a/.ccignore
+++ b/.ccignore
@@ -1,5 +1,7 @@
 README.md
-prepapre-commit-msg
+prepare-commit-msg
 post-commit
-.sh
+test.sh
+test-files/basic.cpp
+testfiles/thing.js
 LICENSE

--- a/post-commit
+++ b/post-commit
@@ -12,12 +12,12 @@ IGNORED=( ".ccignore" )
 # can be found
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 if echo "$DIR" | grep -qs 'git'; then
-  cd "$( echo "$DIR" | grep -Po '^.*(?=(\.git))' )" 
+  cd "$( echo "$DIR" | pcregrep -o '^.*(?=(\.git))' )" 
 fi
 
 if [ -f ".ccignore" ]; then
- while IFS='' read -r line || [[ -n "$line" ]]; do
-   IGNORED+=( "$line" )
+  while IFS='' read -r line || [[ -n "$line" ]]; do
+    IGNORED+=( "$line" )
   done < ".ccignore"
 fi
 


### PR DESCRIPTION
This commit resolves an issue with a GNU grep command using the -P flag.
As a result, users without GNU Grep could not use the Perl Regular
Expressions flag.

This command has been removed and replaced with pcregrep which yields
the same results and also allows forward look-aheads.

Additionally, the test-files have been added to the .ccignore file so
cloning the repository does not cause users to have the test-files in
their first commit message.

Closes #2 
