### PR TITLE
Portability for pcregrep in post-commit hook

### DIFF
--- a/post-commit
+++ b/post-commit
@@ -11,8 +11,15 @@ IGNORED=( ".ccignore" )
 # move to the repository directory so .ccignore file
 # can be found
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if which pcregrep > /dev/null; then
+  grep_git="pcregrep -o '^.*(?=(\.git))'"
+else
+  grep_git="grep -Po '^.*(?=(\.git))'"
+fi
+
 if echo "$DIR" | grep -qs 'git'; then
-  cd "$( echo "$DIR" | pcregrep -o '^.*(?=(\.git))' )" 
+  cd "$( echo "$DIR" | eval "$grep_git" )" 
 fi
 
 if [ -f ".ccignore" ]; then


### PR DESCRIPTION
This commit is being made to address portability for users without
pcregrep as a default package on their system. Some linux distributions
do not ship with pcregrep.

Implementation is borrowed from `post-commit-msg` hook which switches
grep commands depending on availability of pcregrep.

Assumption being made is that if a user does not have pcregrep they will
have GNU grep. Scripts do not suppose any other grep-like commands. An
update will be made to the dependencies section of the project.

Closes #6
