### PR TITLE
Implement file name and line number formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Output in Git commit message
 ```
 # Commit title goes here
 
-- Added a parameter to helloWorld function
-- Concatenated strings
+- [foo.js#1] Added a parameter to helloWorld function
+- [foo.js#3] Concatenated strings
 # Changes to be committed:
 #	modified:   foo.js 
 #

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Contributions to improve simplicity/resolve compatibility would be preferred. If
 
 **TODO**
 
-- [ ] Add filename and line number to bulleted commit commets - [suggestion by
+- [x] Add filename and line number to bulleted commit commets - [suggestion by
   joncalhoun](https://news.ycombinator.com/item?id=10904142) on HN 
 - Create more robust regular expression for validating comment syntax
 	- [ ] Check for multiline block comments

--- a/prepare-commit-msg
+++ b/prepare-commit-msg
@@ -13,6 +13,9 @@
 # Output (in commit message):
 # - Added new link parsing funciton
 
+# Arg 1: SHOW_LINES (T/F)
+SHOW_LINES=true
+
 IGNORED=( ".ccignore" )
 
 # If the script is deployed to the .git directory,
@@ -31,8 +34,10 @@ fi
 
 if which pcregrep > /dev/null; then
   grep_search="pcregrep -o2 '((?:[#;*]|(?:\/{2}))(?:\s+)?@commit(?:[-:.\s]+)?)([^\r\n*\/]+)'"
+  N_grep_search="pcregrep -o2 -n '((?:[#;*]|(?:\/{2}))(?:\s+)?@commit(?:[-:.\s]+)?)([^\r\n*\/]+)'"
 else
   grep_search="grep -Po '(?:[#;*]|(?:\/{2}))(?:\s+)?@commit(?:[-:.\s]+)?\K([^\r\n*\/]+)'"
+  N_grep_search="grep -Po -n '(?:[#;*]|(?:\/{2}))(?:\s+)?@commit(?:[-:.\s]+)?\K([^\r\n*\/]+)'"
 fi
 
 IFS=$'\n' ADDED_FILES=( $(git ls-files) )
@@ -48,13 +53,19 @@ done
 
 comments=""
 for fn in "${ADDED_FILES[@]}"; do
-  temp=$( cat "$fn" | eval "$grep_search" | tr -s '[:space:]' )
+  if [ "$SHOW_LINES" = true ]; then
+    temp=$(cat "$fn" | eval "$N_grep_search" | tr -s '[:space:]' | sed 's/[[:blank:]]*$//' | awk -v fname=$fn -F':' '{ $1 ="[" fname "#" $1 "]"; print}')
+  else
+    temp=$( cat "$fn" | eval "$grep_search" | tr -s '[:space:]' | sed 's/[[:blank:]]*$//' )
+  fi
   if [[ "$temp" != ""  ]]; then
     comments+="$temp"
     comments+="\n"
   fi
 done
+
 comments=$(echo -en "$comments" | sed -e 's/^/- /')
+
 grep -qs "^$comments" "$1"
 if [ $? -eq  1 ]; then
   if [[ "$comments" == "" ]]; then


### PR DESCRIPTION
This commit is being made to implement a feature suggestion from user
johncalhoun on Hacker News.

The file name and line number a commit comment is sourced from will be
made visible on commit comments with the SHOW_LINES variable set to true
in prepare-commit-msg git hook.

Two separate grep searches need to be defined as a result. One grep
search with the -n flag for line numbers, and one without.
Awk is used to modify the field values from grep -n output.

Portability of Awk command needs testing. Initial research suggests
virtually no differences between Awk versions on different
distributions.
